### PR TITLE
Add missing mut to example from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Then, you can use it however you'd like:
 use cat_ascii_faces::Cats;
 
 fn main() {
-    let cats = Cats::new();
+    let mut cats = Cats::new();
     // Print some random cats
     println!("{}", cats.cat()); // (=^･ｪ･^=)
     println!("{}", cats.cat()); // ฅ(⌯͒• ɪ •⌯͒)ฅ❣


### PR DESCRIPTION
We tried out this cute library today and noticed that the Readme example doesn't quite work. This should fix it.